### PR TITLE
Issue 25 deadlock

### DIFF
--- a/nexxT/core/ActiveApplication.py
+++ b/nexxT/core/ActiveApplication.py
@@ -237,13 +237,12 @@ class ActiveApplication(QObject):
         for fromNode, fromPort, toNode, toPort in self._allConnections():
             fromThread = self._filters2threads[fromNode]
             toThread = self._filters2threads[toNode]
-            p0 = self._threads[fromThread].getFilter(fromNode).getPort(fromPort, OutputPortInterface)
-            p1 = self._threads[toThread].getFilter(toNode).getPort(toPort, InputPortInterface)
-            if toThread == fromThread:
-                OutputPortInterface.setupDirectConnection(p0, p1)
-            else:
-                itc = OutputPortInterface.setupInterThreadConnection(p0, p1, self._threads[fromThread].qthread())
-                self._interThreadConns.append(itc)
+            t0 = self._threads[fromThread]
+            p0 = t0.getFilter(fromNode).getPort(fromPort, OutputPortInterface)
+            t1 = self._threads[toThread]
+            p1 = t1.getFilter(toNode).getPort(toPort, InputPortInterface)
+            itc = OutputPortInterface.setupInterThreadConnection(p0, p1, t0, t1)
+            self._interThreadConns.append(itc)
         self._graphConnected = True
 
     @Slot()

--- a/nexxT/core/ActiveApplication.py
+++ b/nexxT/core/ActiveApplication.py
@@ -40,7 +40,7 @@ class ActiveApplication(QObject):
         self._numThreadsSynced = 0
         self._state = FilterState.CONSTRUCTING
         self._graphConnected = False
-        self._interThreadConns = []
+        self._portToPortConns = []
         self._operationInProgress = False
         # connect signals and slots
         for tname in self._threads:
@@ -103,7 +103,7 @@ class ActiveApplication(QObject):
         self._composite2graphs = {}
         # initialize private variables
         self._numThreadsSynced = 0
-        self._interThreadConns = []
+        self._portToPortConns = []
 
     def getState(self):
         """
@@ -241,8 +241,9 @@ class ActiveApplication(QObject):
             p0 = t0.getFilter(fromNode).getPort(fromPort, OutputPortInterface)
             t1 = self._threads[toThread]
             p1 = t1.getFilter(toNode).getPort(toPort, InputPortInterface)
-            itc = OutputPortInterface.setupInterThreadConnection(p0, p1, t0, t1)
-            self._interThreadConns.append(itc)
+            p2pc = OutputPortInterface.setupPortToPortConnection(t0.getExecutor(), t1.getExecutor(), p0, p1)
+            p2pc.moveToThread(t0.qthread())
+            self._portToPortConns.append(p2pc)
         self._graphConnected = True
 
     @Slot()
@@ -348,7 +349,7 @@ class ActiveApplication(QObject):
         self._operationInProgress = True
         self._state = FilterState.STARTING
         self._setupConnections()
-        for itc in self._interThreadConns:
+        for itc in self._portToPortConns:
             # set connections in active mode.
             itc.setStopped(False)
         self.performOperation.emit("start", Barrier(len(self._threads)))
@@ -372,7 +373,7 @@ class ActiveApplication(QObject):
             raise FilterStateMachineError(self._state, FilterState.STOPPING)
         self._operationInProgress = True
         self._state = FilterState.STOPPING
-        for itc in self._interThreadConns:
+        for itc in self._portToPortConns:
             # set connections in active mode.
             itc.setStopped(True)
         self.performOperation.emit("stop", Barrier(len(self._threads)))

--- a/nexxT/core/Executor.py
+++ b/nexxT/core/Executor.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2020 ifm electronic gmbh
+#
+# THE PROGRAM IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND.
+#
+
+"""
+This module defines the class Executor
+"""
+
+import logging
+from PySide2.QtCore import QObject, Signal, QThread, Qt, QMutex, QTimer
+from nexxT.core.Utils import handleException
+
+logger = logging.getLogger(__name__)
+
+class Executor(QObject):
+    """
+    Each nexxT thread has an executor for executing tasks (i.e. notifying filters about changes in the ports).
+    """
+
+    notify = Signal()
+
+    def __init__(self, qthread):
+        """
+        Construtor
+
+        :param qthread: the QThread instance this object shall be moved to
+        """
+        super().__init__()
+        self._pendingReceivesMutex = QMutex()
+        self._pendingReceives = []
+        self._blockedFilters = set()
+        self._stopped = False
+        self.moveToThread(qthread)
+        self.notify.connect(self.notifyInThread, Qt.QueuedConnection)
+
+    def registerPendingRcvSync(self, inputPort, dataSample):
+        """
+        Register a pending synchronous (i.e. originated from the same thread) receive event.
+
+        :param inputPort: The InputPort instance which shall be notified
+        :param dataSample: The DataSample instance to be delivered
+        """
+        self._registerPendingRcvSync(inputPort, dataSample)
+
+    @handleException
+    def _registerPendingRcvSync(self, inputPort, dataSample):
+        if not self._stopped:
+            self._pendingReceives.append((inputPort, dataSample, None))
+            QTimer.singleShot(0, self.step)
+
+    def registerPendingRcvAsync(self, inputPort, dataSample, semaphore):
+        """
+        Register a pending asynchronous (i.e. originated from another thread through a InterThreadConnection instacne)
+        receive event.
+
+        :param inputPort: The InputPort instance which shall be notified
+        :param dataSample: The DataSample instance to be delivered
+        :param semaphore: The QSemaphore instance of the corresponding InterThreadConnection instance
+        """
+        self._registerPendingRcvAsync(inputPort, dataSample, semaphore)
+
+    @handleException
+    def _registerPendingRcvAsync(self, inputPort, dataSample, semaphore):
+        assert inputPort.thread() == self.thread()
+        if not self._stopped:
+            self._pendingReceivesMutex.lock()
+            self._pendingReceives.append((inputPort, dataSample, semaphore))
+            self._pendingReceivesMutex.unlock()
+            self.notify.emit()
+
+    def notifyInThread(self):
+        """
+        Slot called during _registerPendingRcvAsync, starts a single shot timer for the step function.
+        """
+        self._notifyInThread()
+
+    @handleException
+    def _notifyInThread(self):
+        QTimer.singleShot(0, self.step)
+
+    def step(self, fromFilter=None):
+        """
+        This function process one of the pending events.
+
+        :param fromFilter: An optional filter instance which will be blocked for further processing until the function
+            returns
+        :return: True if an event was processed, False otherwise.
+        """
+        return self._step(fromFilter)
+
+    @handleException
+    def _step(self, fromFilter):
+        assert QThread.currentThread() == self.thread()
+        res = False
+        if fromFilter is not None:
+            self._blockedFilters.add(fromFilter)
+        try:
+            if not self._stopped:
+                self._pendingReceivesMutex.lock()
+                for idx, (inputPort, dataSample, semaphore) in enumerate(self._pendingReceives):
+                    if inputPort.environment().getPlugin() not in self._blockedFilters:
+                        self._pendingReceives.pop(idx)
+                        self._pendingReceivesMutex.unlock()
+                        res = True
+                        if semaphore is None:
+                            inputPort.receiveSync(dataSample)
+                        else:
+                            inputPort.receiveAsync(dataSample, semaphore)
+                        # only process one sample
+                        break
+        finally:
+            if not res:
+                self._pendingReceivesMutex.unlock()
+            if fromFilter is not None:
+                self._blockedFilters.remove(fromFilter)
+        return res
+
+    def finalize(self):
+        """
+        This function processes the queue before the thread is stopped. In case of infinite recursions, an early stop
+        criterion is applied.
+        """
+        logger.internal("starting finalize (%s)", self.thread())
+        numCalled = {}
+        changed = True
+        while changed:
+            changed = False
+            self._pendingReceivesMutex.lock()
+            for idx, (inputPort, dataSample, semaphore) in enumerate(self._pendingReceives):
+                if inputPort.environment().getPlugin() not in self._blockedFilters and numCalled.get(inputPort, 0) < 5:
+                    self._pendingReceives.pop(idx)
+                    self._pendingReceivesMutex.unlock()
+                    numCalled[inputPort] = numCalled.get(inputPort, 0) + 1
+                    changed = True
+                    if semaphore is None:
+                        inputPort.receiveSync(dataSample)
+                    else:
+                        inputPort.receiveAsync(dataSample, semaphore)
+                    self._pendingReceivesMutex.lock()
+                    # only one sample, note that _pendingReceives is changed inside the loop!
+                    break
+            self._pendingReceivesMutex.unlock()
+
+    def clear(self):
+        """
+        Called after processing is stopped.
+        """
+        self._stopped = True
+        self._pendingReceives = []
+        self._blockedFilters = []

--- a/nexxT/core/Executor.py
+++ b/nexxT/core/Executor.py
@@ -10,143 +10,161 @@ This module defines the class Executor
 
 import logging
 from PySide2.QtCore import QObject, Signal, QThread, Qt, QMutex, QTimer
+import nexxT
 from nexxT.core.Utils import handleException
 
 logger = logging.getLogger(__name__)
 
-class Executor(QObject):
-    """
-    Each nexxT thread has an executor for executing tasks (i.e. notifying filters about changes in the ports).
-    """
+if nexxT.useCImpl:
 
-    notify = Signal()
+    import cnexxT
 
-    def __init__(self, qthread):
+    def Executor(*args): # pylint: disable=invalid-name
         """
-        Construtor
-
-        :param qthread: the QThread instance this object shall be moved to
+        This is a factory function for the C version of the Executor class
         """
-        super().__init__()
-        self._pendingReceivesMutex = QMutex()
-        self._pendingReceives = []
-        self._blockedFilters = set()
-        self._stopped = False
-        self.moveToThread(qthread)
-        self.notify.connect(self.notifyInThread, Qt.QueuedConnection)
+        res = cnexxT.nexxT.Executor.make_shared(cnexxT.nexxT.Executor(*args))
+        return res
 
-    def registerPendingRcvSync(self, inputPort, dataSample):
+else:
+
+    class Executor(QObject):
         """
-        Register a pending synchronous (i.e. originated from the same thread) receive event.
-
-        :param inputPort: The InputPort instance which shall be notified
-        :param dataSample: The DataSample instance to be delivered
+        Each nexxT thread has an executor for executing tasks (i.e. notifying filters about changes in the ports).
         """
-        self._registerPendingRcvSync(inputPort, dataSample)
 
-    @handleException
-    def _registerPendingRcvSync(self, inputPort, dataSample):
-        if not self._stopped:
-            self._pendingReceives.append((inputPort, dataSample, None))
-            QTimer.singleShot(0, self.step)
+        notify = Signal()
+        MAX_LOOPS_FINALIZE = 5
 
-    def registerPendingRcvAsync(self, inputPort, dataSample, semaphore):
-        """
-        Register a pending asynchronous (i.e. originated from another thread through a InterThreadConnection instacne)
-        receive event.
+        def __init__(self, qthread):
+            """
+            Construtor
 
-        :param inputPort: The InputPort instance which shall be notified
-        :param dataSample: The DataSample instance to be delivered
-        :param semaphore: The QSemaphore instance of the corresponding InterThreadConnection instance
-        """
-        self._registerPendingRcvAsync(inputPort, dataSample, semaphore)
+            :param qthread: the QThread instance this object shall be moved to
+            """
+            super().__init__()
+            self._pendingReceivesMutex = QMutex()
+            self._pendingReceives = []
+            self._blockedFilters = set()
+            self._stopped = False
+            self.moveToThread(qthread)
+            self.notify.connect(self.notifyInThread, Qt.QueuedConnection)
 
-    @handleException
-    def _registerPendingRcvAsync(self, inputPort, dataSample, semaphore):
-        assert inputPort.thread() == self.thread()
-        if not self._stopped:
-            self._pendingReceivesMutex.lock()
-            self._pendingReceives.append((inputPort, dataSample, semaphore))
-            self._pendingReceivesMutex.unlock()
-            self.notify.emit()
+        def registerPendingRcvSync(self, inputPort, dataSample):
+            """
+            Register a pending synchronous (i.e. originated from the same thread) receive event.
 
-    def notifyInThread(self):
-        """
-        Slot called during _registerPendingRcvAsync, starts a single shot timer for the step function.
-        """
-        self._notifyInThread()
+            :param inputPort: The InputPort instance which shall be notified
+            :param dataSample: The DataSample instance to be delivered
+            """
+            self._registerPendingRcvSync(inputPort, dataSample)
 
-    @handleException
-    def _notifyInThread(self):
-        QTimer.singleShot(0, self.step)
-
-    def step(self, fromFilter=None):
-        """
-        This function process one of the pending events.
-
-        :param fromFilter: An optional filter instance which will be blocked for further processing until the function
-            returns
-        :return: True if an event was processed, False otherwise.
-        """
-        return self._step(fromFilter)
-
-    @handleException
-    def _step(self, fromFilter):
-        assert QThread.currentThread() == self.thread()
-        res = False
-        if fromFilter is not None:
-            self._blockedFilters.add(fromFilter)
-        try:
+        @handleException
+        def _registerPendingRcvSync(self, inputPort, dataSample):
             if not self._stopped:
                 self._pendingReceivesMutex.lock()
+                self._pendingReceives.append((inputPort, dataSample, None))
+                self._pendingReceivesMutex.unlock()
+                QTimer.singleShot(0, self.step)
+
+        def registerPendingRcvAsync(self, inputPort, dataSample, semaphore):
+            """
+            Register a pending asynchronous (i.e. originated from another thread through a PortToPortConnection
+            instacne) receive event.
+
+            :param inputPort: The InputPort instance which shall be notified
+            :param dataSample: The DataSample instance to be delivered
+            :param semaphore: The QSemaphore instance of the corresponding InterThreadConnection instance
+            """
+            self._registerPendingRcvAsync(inputPort, dataSample, semaphore)
+
+        @handleException
+        def _registerPendingRcvAsync(self, inputPort, dataSample, semaphore):
+            assert inputPort.thread() == self.thread()
+            if not self._stopped:
+                self._pendingReceivesMutex.lock()
+                self._pendingReceives.append((inputPort, dataSample, semaphore))
+                self._pendingReceivesMutex.unlock()
+                self.notify.emit()
+
+        def notifyInThread(self):
+            """
+            Slot called during _registerPendingRcvAsync, starts a single shot timer for the step function.
+            """
+            self._notifyInThread()
+
+        @handleException
+        def _notifyInThread(self):
+            QTimer.singleShot(0, self.step)
+
+        def step(self, fromFilter=None):
+            """
+            This function process one of the pending events.
+
+            :param fromFilter: An optional filter instance which will be blocked for further processing until the
+                function returns
+            :return: True if an event was processed, False otherwise.
+            """
+            return self._step(fromFilter)
+
+        @handleException
+        def _step(self, fromFilter):
+            assert QThread.currentThread() == self.thread()
+            res = False
+            if fromFilter is not None:
+                self._blockedFilters.add(fromFilter)
+            try:
+                if not self._stopped:
+                    self._pendingReceivesMutex.lock()
+                    for idx, (inputPort, dataSample, semaphore) in enumerate(self._pendingReceives):
+                        if inputPort.environment().getPlugin() not in self._blockedFilters:
+                            self._pendingReceives.pop(idx)
+                            self._pendingReceivesMutex.unlock()
+                            res = True
+                            if semaphore is None:
+                                inputPort.receiveSync(dataSample)
+                            else:
+                                inputPort.receiveAsync(dataSample, semaphore)
+                            # only process one sample
+                            break
+            finally:
+                if not res:
+                    self._pendingReceivesMutex.unlock()
+                if fromFilter is not None:
+                    self._blockedFilters.remove(fromFilter)
+            return res
+
+        def finalize(self):
+            """
+            This function processes the queue before the thread is stopped. In case of infinite recursions, an early
+            stop criterion is applied.
+            """
+            logger.internal("starting finalize (%s)", self.thread())
+            numCalled = {}
+            changed = True
+            while changed:
+                changed = False
+                self._pendingReceivesMutex.lock()
                 for idx, (inputPort, dataSample, semaphore) in enumerate(self._pendingReceives):
-                    if inputPort.environment().getPlugin() not in self._blockedFilters:
+                    if (inputPort.environment().getPlugin() not in self._blockedFilters and
+                            numCalled.get(inputPort, 0) < self.MAX_LOOPS_FINALIZE):
                         self._pendingReceives.pop(idx)
                         self._pendingReceivesMutex.unlock()
-                        res = True
+                        numCalled[inputPort] = numCalled.get(inputPort, 0) + 1
+                        changed = True
                         if semaphore is None:
                             inputPort.receiveSync(dataSample)
                         else:
                             inputPort.receiveAsync(dataSample, semaphore)
-                        # only process one sample
+                        self._pendingReceivesMutex.lock()
+                        # only one sample, note that _pendingReceives is changed inside the loop!
                         break
-        finally:
-            if not res:
                 self._pendingReceivesMutex.unlock()
-            if fromFilter is not None:
-                self._blockedFilters.remove(fromFilter)
-        return res
 
-    def finalize(self):
-        """
-        This function processes the queue before the thread is stopped. In case of infinite recursions, an early stop
-        criterion is applied.
-        """
-        logger.internal("starting finalize (%s)", self.thread())
-        numCalled = {}
-        changed = True
-        while changed:
-            changed = False
-            self._pendingReceivesMutex.lock()
-            for idx, (inputPort, dataSample, semaphore) in enumerate(self._pendingReceives):
-                if inputPort.environment().getPlugin() not in self._blockedFilters and numCalled.get(inputPort, 0) < 5:
-                    self._pendingReceives.pop(idx)
-                    self._pendingReceivesMutex.unlock()
-                    numCalled[inputPort] = numCalled.get(inputPort, 0) + 1
-                    changed = True
-                    if semaphore is None:
-                        inputPort.receiveSync(dataSample)
-                    else:
-                        inputPort.receiveAsync(dataSample, semaphore)
-                    self._pendingReceivesMutex.lock()
-                    # only one sample, note that _pendingReceives is changed inside the loop!
-                    break
-            self._pendingReceivesMutex.unlock()
-
-    def clear(self):
-        """
-        Called after processing is stopped.
-        """
-        self._stopped = True
-        self._pendingReceives = []
-        self._blockedFilters = []
+        def clear(self):
+            """
+            Called after processing is stopped.
+            """
+            self._stopped = True
+            self._pendingReceives = []
+            self._blockedFilters = []

--- a/nexxT/core/PropertyHandlers.py
+++ b/nexxT/core/PropertyHandlers.py
@@ -10,7 +10,6 @@ This module contains the specific nexxT property handlers for the supported type
 
 import logging
 from PySide2.QtWidgets import QSpinBox, QLineEdit, QComboBox
-from PySide2.QtGui import QDoubleValidator
 from nexxT.interface import PropertyHandler
 from nexxT.core.Exceptions import PropertyParsingError, PropertyCollectionUnknownType
 
@@ -302,10 +301,6 @@ class FloatHandler(PropertyHandler):
         :return: a QLineEdit instance
         """
         res = QLineEdit(parent)
-        v = QDoubleValidator()
-        # QDoubleValidator seems to have a very strange behaviour when bottom and/or top values are set.
-        # Therefore, we don't use this feature and rely on our own implementation.
-        res.setValidator(v)
         res.setFrame(False)
         return res
 

--- a/nexxT/interface/Services.py
+++ b/nexxT/interface/Services.py
@@ -31,6 +31,9 @@ class Services:
     directly via QMetaObject::invokeMethod in C++. In python this is normally not needed because a wrapped QObject will
     offer to call slots directly via python calls.
 
+    If the special slot detach() is available in a service, this slot will be called immediately before the service is
+    removed from the framework (usually at application exit time).
+
     .. note::
         Usually, nexxT is using the wrapped C++ class instead of the python version. In python there are no
         differences between the wrapped C++ class and this python class. The C++ interface is defined in
@@ -69,6 +72,10 @@ class Services:
         :param name: the name of the service
         :return: the related QObject instance
         """
+        try:
+            Services.services[name].detach()
+        except: # pylint: disable=bare-except
+            pass
         del Services.services[name]
 
     @staticmethod

--- a/nexxT/interface/__init__.py
+++ b/nexxT/interface/__init__.py
@@ -41,7 +41,7 @@ else:
     from nexxT.core import PortImpl
     OutputPort = PortImpl.OutputPortImpl
     InputPort = PortImpl.InputPortImpl
-    OutputPortInterface.setupInterThreadConnection = OutputPort.setupInterThreadConnection
+    OutputPortInterface.setupPortToPortConnection = OutputPort.setupPortToPortConnection
     del PortImpl
     from nexxT.interface.Filters import Filter, FilterState, FilterSurrogate
     from nexxT.interface.DataSamples import DataSample

--- a/nexxT/interface/__init__.py
+++ b/nexxT/interface/__init__.py
@@ -41,7 +41,6 @@ else:
     from nexxT.core import PortImpl
     OutputPort = PortImpl.OutputPortImpl
     InputPort = PortImpl.InputPortImpl
-    OutputPortInterface.setupDirectConnection = OutputPort.setupDirectConnection
     OutputPortInterface.setupInterThreadConnection = OutputPort.setupInterThreadConnection
     del PortImpl
     from nexxT.interface.Filters import Filter, FilterState, FilterSurrogate

--- a/nexxT/services/SrvPlaybackControl.py
+++ b/nexxT/services/SrvPlaybackControl.py
@@ -95,14 +95,14 @@ class PlaybackDeviceProxy(QObject):
         if self._controlsFile:
             self._seekEnd.emit()
 
-    def seekTime(self, timestamp_ns):
+    def seekTime(self, timestampNS):
         """
         Proxy function, checks whether this proxy has control and emits the signal if necessary
 
-        :param timestamp_ns: the timestamp in nanoseconds
+        :param timestampNS: the timestamp in nanoseconds
         """
         if self._controlsFile:
-            self._seekTime.emit(timestamp_ns)
+            self._seekTime.emit(timestampNS)
 
     def setSequence(self, filename):
         """
@@ -433,14 +433,14 @@ class PlaybackControlConsole(MVCPlaybackControlBase):
         """
         self._seekEnd.emit()
 
-    def seekTime(self, timestamp_ns):
+    def seekTime(self, timestampNS):
         """
         Seek to the specified time
 
-        :param timestamp_ns: the timestamp in nanoseconds
+        :param timestampNS: the timestamp in nanoseconds
         :return:
         """
-        self._seekTime.emit(timestamp_ns)
+        self._seekTime.emit(timestampNS)
 
     def setSequence(self, file):
         """

--- a/nexxT/services/gui/BrowserWidget.py
+++ b/nexxT/services/gui/BrowserWidget.py
@@ -166,7 +166,7 @@ class FolderListModel(QAbstractTableModel):
                 return s
             if index.column() == 2:
                 try:
-                    return QDateTime.fromMSecsSinceEpoch(c.stat().st_mtime*1000)
+                    return QDateTime.fromMSecsSinceEpoch(int(c.stat().st_mtime*1000))
                 except Exception: # pylint: disable=broad-except
                     return ""
         if role == Qt.DecorationRole:

--- a/nexxT/services/gui/Configuration.py
+++ b/nexxT/services/gui/Configuration.py
@@ -58,8 +58,10 @@ class MVCConfigurationGUI(MVCConfigurationBase):
         self.actActivate = QAction(QIcon.fromTheme("arrow-up", style.standardIcon(QStyle.SP_ArrowUp)),
                                    "Initialize", self)
         self.actActivate.triggered.connect(self.activate)
+        self.actActivate.setShortcut(QKeySequence(Qt.CTRL + Qt.Key_I))
         self.actDeactivate = QAction(QIcon.fromTheme("arrow-down", style.standardIcon(QStyle.SP_ArrowDown)),
                                      "Deinitialize", self)
+        self.actDeactivate.setShortcut(QKeySequence(Qt.CTRL + Qt.Key_D))
         self.actDeactivate.triggered.connect(self.deactivate)
 
         confMenu.addAction(self.actLoad)

--- a/nexxT/services/gui/GuiLogger.py
+++ b/nexxT/services/gui/GuiLogger.py
@@ -12,7 +12,7 @@ from queue import Queue
 import traceback
 import logging
 import shiboken2
-from PySide2.QtCore import Qt, QTimer, QAbstractItemModel, QModelIndex
+from PySide2.QtCore import Qt, QTimer, QAbstractItemModel, QModelIndex, Slot
 from PySide2.QtWidgets import QTableView, QHeaderView, QAction, QActionGroup
 from PySide2.QtGui import QColor
 from nexxT.services.ConsoleLogger import ConsoleLogger
@@ -343,7 +343,7 @@ class GuiLogger(ConsoleLogger):
         mainLogger = logging.getLogger()
         self.handler = LogHandler(self.logWidget)
         mainLogger.addHandler(self.handler)
-        self.logWidget.destroyed.connect(lambda: mainLogger.removeHandler(self.handler))
+        self.destroyed.connect(self.removeHandler)
 
         self.actFollow = QAction("Follow")
         self.actFollow.setCheckable(True)
@@ -385,6 +385,22 @@ class GuiLogger(ConsoleLogger):
         logMenu.addAction(self.actClear)
         logMenu.addAction(self.actFollow)
         logMenu.addAction(self.actSingleLine)
+
+    @Slot()
+    def detach(self):
+        """
+        This slot is called when the service is removed from the framework
+        """
+        self.removeHandler()
+
+    def removeHandler(self):
+        """
+        Remove logging handler from python logging system.
+        """
+        mainLogger = logging.getLogger()
+        if self.handler is not None:
+            mainLogger.removeHandler(self.handler)
+            self.handler = None
 
     def setLogLevel(self):
         """

--- a/nexxT/services/gui/MainWindow.py
+++ b/nexxT/services/gui/MainWindow.py
@@ -461,8 +461,24 @@ with the <a href='https://github.com/ifm/nexxT/blob/master/NOTICE'>notice</a>.
 
     def _registerWindow(self, window, nameChangedSignal):
         act = QAction("<unnamed>", self)
+        def ensureVisible():
+            window.setVisible(True)
+            act.setChecked(True)
+            window.raise_()
+            if isinstance(window, QMdiSubWindow):
+                self.mdi.setActiveSubWindow(window)
+                x = self.mdi.horizontalScrollBar().value()
+                y = self.mdi.verticalScrollBar().value()
+                w = self.mdi.viewport().width()
+                h = self.mdi.viewport().height()
+                r = QRect(x, y, w, h)
+                g = window.geometry()
+                logger.info("r=%s w=%s", r, g)
+                if not r.intersects(g):
+                    self.mdi.horizontalScrollBar().setValue(g.x())
+                    self.mdi.verticalScrollBar().setValue(g.y())
         act.setCheckable(True)
-        act.toggled.connect(window.setVisible)
+        act.triggered.connect(ensureVisible)
         window.visibleChanged.connect(act.setChecked)
         nameChangedSignal.connect(act.setText)
         self.windows[shiboken2.getCppPointer(window)[0]] = act # pylint: disable=no-member

--- a/nexxT/services/gui/PlaybackControl.py
+++ b/nexxT/services/gui/PlaybackControl.py
@@ -69,8 +69,8 @@ class MVCPlaybackControlGUI(PlaybackControlConsole):
         # let's stay on the safe side and do not use emit as a slot...
         self.actStart.triggered.connect(self.startPlayback)
         self.actPause.triggered.connect(self.pausePlayback)
-        self.actStepFwd.triggered.connect(lambda: self.stepForward(self.selectedStream()))
-        self.actStepBwd.triggered.connect(lambda: self.stepBackward(self.selectedStream()))
+        self.actStepFwd.triggered.connect(self._stepForwardActivated)
+        self.actStepBwd.triggered.connect(self._stepBackwardActivated)
         self.actSeekEnd.triggered.connect(self.seekEnd)
         self.actSeekBegin.triggered.connect(self.seekBeginning)
         # pylint: enable=unnecessary-lambda
@@ -246,7 +246,8 @@ class MVCPlaybackControlGUI(PlaybackControlConsole):
             self.actGroupStream.removeAction(a)
         for stream in streams:
             act = QAction(stream, self.actGroupStream)
-            act.triggered.connect(lambda cstream=stream: self.setSelectedStream(cstream))
+            act.setData(stream)
+            act.triggered.connect(self._setSelectedStreamActivated)
             act.setCheckable(True)
             act.setChecked(False)
             logger.debug("Add stream group action: %s", act.data())
@@ -343,6 +344,16 @@ class MVCPlaybackControlGUI(PlaybackControlConsole):
             self.actStart.setEnabled(True)
         self.actPause.setEnabled(False)
         super()._playbackPaused()
+
+    def _setSelectedStreamActivated(self):
+        stream = self.sender().data()
+        self.setSelectedStream(stream)
+
+    def _stepForwardActivated(self):
+        self.stepForward(self.selectedStream())
+
+    def _stepBackwardActivated(self):
+        self.stepBackward(self.selectedStream())
 
     def openRecent(self):
         """

--- a/nexxT/src/DataSamples.hpp
+++ b/nexxT/src/DataSamples.hpp
@@ -19,16 +19,11 @@
 #include <QtCore/QSharedPointer>
 
 #include "NexxTLinkage.hpp"
+#include "SharedPointerTypes.hpp"
 
 namespace nexxT
 {
     struct DataSampleD;
-    class DataSample;
-
-    /*!
-        A typedef for a Datasample handled by a shared pointer.
-    */
-    typedef QSharedPointer<const DataSample> SharedDataSamplePtr;
 
     /*!
         This class is the C++ variant of \verbatim embed:rst:inline :py:class:`nexxT.interface.DataSamples.DataSample`

--- a/nexxT/src/Executor.cpp
+++ b/nexxT/src/Executor.cpp
@@ -1,0 +1,220 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2020 ifm electronic gmbh
+ *
+ * THE PROGRAM IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND.
+ */
+
+#include "Executor.hpp"
+#include "FilterEnvironment.hpp"
+#include "InputPortInterface.hpp"
+#include "OutputPortInterface.hpp"
+#include "Logger.hpp"
+
+#include <QtCore/QThread>
+#include <QtCore/Qt>
+#include <QtCore/QMutex>
+#include <QtCore/QMutexLocker>
+#include <QtCore/QSemaphore>
+#include <QtCore/QTimer>
+
+#include <vector>
+#include <set>
+
+using namespace nexxT;
+
+namespace nexxT
+{
+    struct ExecutorD
+    {
+        struct ReceiveEvent
+        {
+            SharedInputPortPtr inputPort;
+            SharedDataSamplePtr dataSample;
+            QSemaphore *semaphore;
+        };
+
+        static const int MAX_LOOPS_FINALIZE = 5;
+
+        QMutex pendingReceivesMutex;
+        std::vector<ReceiveEvent> pendingReceives;
+        std::set<Filter *> blockedFilters;
+        bool stopped;
+    };
+};
+
+Executor::Executor(QThread *qthread) :
+    QObject(),
+    d(new ExecutorD())
+{
+    moveToThread(qthread);
+    QObject::connect(this, SIGNAL(notify()), this, SLOT(notifyInThread()), Qt::QueuedConnection);
+}
+
+Executor::~Executor()
+{
+    delete d;
+}
+
+void Executor::registerPendingRcvSync(const SharedInputPortPtr &inputPort,
+                                      const SharedDataSamplePtr &dataSample)
+{
+    if( !d->stopped )
+    {
+        ExecutorD::ReceiveEvent ev{inputPort, dataSample, 0};
+        {
+            QMutexLocker locker(&d->pendingReceivesMutex);
+            //NEXXT_LOG_INFO(QString("add to executor queue %1/%2 (sync)").
+            //    arg(inputPort->environment()->getFullQualifiedName()).
+            //    arg(inputPort->name()));
+            d->pendingReceives.push_back(ev);
+        }
+        notifyInThread();
+    }
+}
+
+void Executor::registerPendingRcvAsync(const SharedInputPortPtr &inputPort,
+                                       const SharedDataSamplePtr &dataSample,
+                                       QSemaphore *semaphore)
+{
+    if( !d->stopped )
+    {
+        ExecutorD::ReceiveEvent ev{inputPort, dataSample, semaphore};
+        {
+            QMutexLocker locker(&d->pendingReceivesMutex);
+            //NEXXT_LOG_INFO(QString("add to executor queue %1/%2 (async)").
+            //   arg(inputPort->environment()->getFullQualifiedName()).arg(inputPort->name()));
+            d->pendingReceives.push_back(ev);
+        }
+        emit notify();
+    }
+}
+
+void Executor::notifyInThread()
+{
+    if( QThread::currentThread() != thread() )
+    {
+        NEXXT_LOG_ERROR("Executor::notifyInThread: Unexpected thread!");
+    }
+    //NEXXT_LOG_INFO(QString("[%1] calling step via QT event.").arg(QThread::currentThread()->objectName()));
+    QTimer::singleShot(0, this, SLOT(step()));
+}
+
+struct StepFunctionHelper
+{
+    const SharedFilterPtr &fromFilter;
+    ExecutorD *d;
+    bool &res;
+
+    StepFunctionHelper(const SharedFilterPtr &_fromFilter, ExecutorD *_d, bool &_res) :
+        fromFilter(_fromFilter),
+        d(_d),
+        res(_res)
+    {
+        if( fromFilter.get() != 0 )
+        {
+            //NEXXT_LOG_INFO(QString("[%1] Entering Executor::step, blocking filter %2").
+            //    arg(QThread::currentThread()->objectName()).
+            //    arg(fromFilter->environment()->getFullQualifiedName()));
+            d->blockedFilters.insert(fromFilter.get());
+        } else
+        {
+            //NEXXT_LOG_INFO(QString("[%1] Entering Executor::step without blocking").
+            //    arg(QThread::currentThread()->objectName()));
+        }
+    }
+    ~StepFunctionHelper()
+    {
+        if( !res )
+        {
+            d->pendingReceivesMutex.unlock();
+        }
+        if( fromFilter.get() != 0 )
+        {
+            //NEXXT_LOG_INFO(QString("[%1] Unblocking filter %2").
+            //    arg(QThread::currentThread()->objectName()).
+            //    arg(fromFilter->environment()->getFullQualifiedName()));
+            d->blockedFilters.erase(fromFilter.get());
+        }
+        //NEXXT_LOG_INFO(QString("[%1] Leaving Executor::step").
+        //    arg(QThread::currentThread()->objectName()));
+    }
+};
+
+bool Executor::step(const SharedFilterPtr &fromFilter)
+{
+    bool res = false;
+    if( !d->stopped )
+    {
+        StepFunctionHelper helper(fromFilter, d, res);
+        d->pendingReceivesMutex.lock();
+        for(auto it=d->pendingReceives.begin(); it != d->pendingReceives.end(); it++)
+        {
+            if( d->blockedFilters.empty() ||
+                d->blockedFilters.count(it->inputPort->environment()->getPlugin().get()) == 0 )
+            {
+                ExecutorD::ReceiveEvent ev(*it);
+                d->pendingReceives.erase(it);
+                /* it is invalid from here on */
+                d->pendingReceivesMutex.unlock();
+                res = true;
+                if( !ev.semaphore )
+                {
+                    ev.inputPort->receiveSync(ev.dataSample);
+                } else
+                {
+                    ev.inputPort->receiveAsync(ev.dataSample, ev.semaphore);
+                }
+                break;
+            }
+        }
+    }
+    return res;
+}
+
+void Executor::finalize()
+{
+    std::multiset<InputPortInterface *> numCalled;
+    bool changed = true;
+    while(changed)
+    {
+        changed = false;
+        d->pendingReceivesMutex.lock();
+        for(auto it=d->pendingReceives.begin(); it != d->pendingReceives.end(); it++)
+        {
+            bool cond1 = d->blockedFilters.count(it->inputPort->environment()->getPlugin().get()) == 0;
+            bool cond2 = numCalled.count(it->inputPort.get()) < d->MAX_LOOPS_FINALIZE;
+            if(cond1 && cond2)
+            {
+                ExecutorD::ReceiveEvent ev(*it);
+                d->pendingReceives.erase(it);
+                /* it is invalid from here on */
+                d->pendingReceivesMutex.unlock();
+                changed = true;
+                numCalled.insert(ev.inputPort.get());
+                if( !ev.semaphore )
+                {
+                    ev.inputPort->receiveSync(ev.dataSample);
+                } else
+                {
+                    ev.inputPort->receiveAsync(ev.dataSample, ev.semaphore);
+                }
+                d->pendingReceivesMutex.lock();
+                break;
+            }
+        }
+        d->pendingReceivesMutex.unlock();
+    }
+}
+
+void Executor::clear()
+{
+    d->stopped = true;
+    d->pendingReceives.clear();
+    d->blockedFilters.clear();
+}
+
+SharedExecutorPtr Executor::make_shared(Executor *executor)
+{
+    return SharedExecutorPtr(executor);
+}

--- a/nexxT/src/Executor.hpp
+++ b/nexxT/src/Executor.hpp
@@ -1,0 +1,93 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2020 ifm electronic gmbh
+ *
+ * THE PROGRAM IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND.
+ */
+
+/**
+    \file Executor.hpp
+    This file is the c++ version of \verbatim embed:rst :py:mod:`nexxT.core.Executor` \endverbatim
+*/
+
+#ifndef NEXXT_EXECUTOR_HPP
+#define NEXXT_EXECUTOR_HPP
+
+#include <QtCore/QObject>
+
+#include "SharedPointerTypes.hpp"
+#include "Filters.hpp"
+#include "DataSamples.hpp"
+#include "NexxTLinkage.hpp"
+
+class QSemaphore;
+class QThread;
+
+//! @cond Doxygen_Suppress
+namespace nexxT
+{
+    struct ExecutorD;
+
+    /*!
+        This class is the C++ variant of \verbatim embed:rst:inline :py:class:`nexxT.core.Executor.Executor`
+        \endverbatim
+    */
+    class DLLEXPORT Executor: public QObject
+    {
+        Q_OBJECT
+
+        ExecutorD *d;
+    public:
+        /*!
+            Constructor, see \verbatim embed:rst:inline :py:meth:`nexxT.core.Executor.Executor.__init__`
+            \endverbatim
+        */
+        Executor(QThread *qthread);
+        /*!
+            Destructor
+        */
+        virtual ~Executor();
+
+        /*!
+            See \verbatim embed:rst:inline :py:meth:`nexxT.core.Executor.Executor.getContent` \endverbatim
+        */
+        void finalize();
+        /*!
+            See \verbatim embed:rst:inline :py:meth:`nexxT.core.Executor.Executor.clear` \endverbatim
+        */
+        void clear();
+
+        /*!
+            Returns a shared pointer of the given executor instance, which takes the ownership of the instance.
+        */
+        static SharedExecutorPtr make_shared(Executor *executor);
+
+    signals:
+
+        /*!
+            See \verbatim embed:rst:inline :py:meth:`nexxT.core.Executor.Executor.notify` \endverbatim
+        */
+        void notify();
+
+    public slots:
+        /*!
+            See \verbatim embed:rst:inline :py:meth:`nexxT.core.Executor.Executor.registerPendingRcvSync` \endverbatim
+        */
+        void registerPendingRcvSync(const SharedInputPortPtr &inputPort, const SharedDataSamplePtr &dataSample);
+        /*!
+            See \verbatim embed:rst:inline :py:meth:`nexxT.core.Executor.Executor.registerPendingRcvAsync` \endverbatim
+        */
+        void registerPendingRcvAsync(const SharedInputPortPtr &inputPort, const SharedDataSamplePtr &dataSample, QSemaphore *semaphore);
+        /*!
+            See \verbatim embed:rst:inline :py:meth:`nexxT.core.Executor.Executor.notifyInThread` \endverbatim
+        */
+        void notifyInThread();
+        /*!
+            See \verbatim embed:rst:inline :py:meth:`nexxT.core.Executor.Executor.step` \endverbatim
+        */
+        bool step(const SharedFilterPtr &fromFilter = SharedFilterPtr());
+    };
+};
+//! @endcond
+
+#endif

--- a/nexxT/src/Executor.hpp
+++ b/nexxT/src/Executor.hpp
@@ -69,6 +69,12 @@ namespace nexxT
         */
         void notify();
 
+    protected slots:
+        /*!
+            This function processes a bunch of step() functions. It's only called via QTimer::singleShot
+        */
+        void multiStep();
+
     public slots:
         /*!
             See \verbatim embed:rst:inline :py:meth:`nexxT.core.Executor.Executor.registerPendingRcvSync` \endverbatim

--- a/nexxT/src/FilterEnvironment.hpp
+++ b/nexxT/src/FilterEnvironment.hpp
@@ -10,7 +10,7 @@
 
 #include <QtCore/QObject>
 
-#include "Ports.hpp"
+#include "SharedPointerTypes.hpp"
 #include "Filters.hpp"
 #include "NexxTLinkage.hpp"
 

--- a/nexxT/src/Filters.cpp
+++ b/nexxT/src/Filters.cpp
@@ -8,6 +8,8 @@
 #include "Filters.hpp"
 #include "FilterEnvironment.hpp"
 #include "Ports.hpp"
+#include "InputPortInterface.hpp"
+#include "OutputPortInterface.hpp"
 #include "Logger.hpp"
 
 using namespace nexxT;

--- a/nexxT/src/Filters.hpp
+++ b/nexxT/src/Filters.hpp
@@ -19,8 +19,7 @@
 #include <QtCore/QList>
 
 #include "NexxTLinkage.hpp"
-#include "InputPortInterface.hpp"
-#include "OutputPortInterface.hpp"
+#include "SharedPointerTypes.hpp"
 
 namespace nexxT
 {

--- a/nexxT/src/InputPortInterface.cpp
+++ b/nexxT/src/InputPortInterface.cpp
@@ -11,6 +11,7 @@
 #include "Filters.hpp"
 #include "Logger.hpp"
 #include "Services.hpp"
+#include "Logger.hpp"
 #include <atomic>
 
 #include <QtCore/QThread>

--- a/nexxT/src/InputPortInterface.hpp
+++ b/nexxT/src/InputPortInterface.hpp
@@ -6,7 +6,7 @@
  */
 
 /**
-    \file OutputPortInterface.hpp
+    \file InputPortInterface.hpp
     The interface corresponding to \verbatim embed:rst :py:mod:`nexxT.interface.Ports` \endverbatim
 */
 
@@ -16,7 +16,7 @@
 #include <QtCore/QObject>
 #include <QtCore/QSemaphore>
 #include "NexxTLinkage.hpp"
-#include "DataSamples.hpp"
+#include "SharedPointerTypes.hpp"
 #include "Ports.hpp"
 
 namespace nexxT

--- a/nexxT/src/NexxTPlugins.hpp
+++ b/nexxT/src/NexxTPlugins.hpp
@@ -15,6 +15,11 @@
 #define NEXXT_PLUGINS_HPP
 
 #include "Filters.hpp"
+/* included for convenience, these headers are usually needed in every filter */
+#include "DataSamples.hpp"
+#include "SharedPointerTypes.hpp"
+#include "OutputPortInterface.hpp"
+#include "InputPortInterface.hpp"
 #include <QtCore/QLibrary>
 
 /*!

--- a/nexxT/src/OutputPortInterface.cpp
+++ b/nexxT/src/OutputPortInterface.cpp
@@ -12,6 +12,7 @@
 #include "Filters.hpp"
 #include "Logger.hpp"
 #include "Services.hpp"
+#include "Executor.hpp"
 #include <atomic>
 
 #include <QtCore/QThread>
@@ -39,22 +40,25 @@ SharedPortPtr OutputPortInterface::clone(BaseFilterEnvironment *env) const
     return SharedPortPtr(new OutputPortInterface(dynamic(), name(), env));
 }
 
-void OutputPortInterface::setupDirectConnection(const SharedPortPtr &op, const SharedPortPtr &ip)
+QObject *OutputPortInterface::setupPortToPortConnection(const SharedExecutorPtr &executorFrom,
+                                                        const SharedExecutorPtr &executorTo,
+                                                        const SharedPortPtr &_outputPort,
+                                                        const SharedPortPtr &_inputPort)
 {
-    const OutputPortInterface *p0 = dynamic_cast<const OutputPortInterface *>(op.data());
-    const InputPortInterface *p1 = dynamic_cast<const InputPortInterface *>(ip.data());
+    SharedOutputPortPtr outputPort = _outputPort.dynamicCast<OutputPortInterface>();
+    SharedInputPortPtr inputPort = _inputPort.dynamicCast<InputPortInterface>();
+    PortToPortConnection *p2pc = new PortToPortConnection(executorFrom, executorTo, outputPort, inputPort);
+    if( outputPort->thread() != executorFrom->thread() )
+    {
+        NEXXT_LOG_ERROR("Unexpected threads (outputPort vs executorFrom)");
+    }
+    if( inputPort->thread() != executorTo->thread() )
+    {
+        NEXXT_LOG_ERROR("Unexpected threads (inputPort vs executorTo)");
+    }
+    const OutputPortInterface *p0 = dynamic_cast<const OutputPortInterface *>(outputPort.data());
     QObject::connect(p0, SIGNAL(transmitSample(const QSharedPointer<const nexxT::DataSample>&)),
-                     p1, SLOT(receiveSync(const QSharedPointer<const nexxT::DataSample> &)));
-}
-
-QObject *OutputPortInterface::setupInterThreadConnection(const SharedPortPtr &op, const SharedPortPtr &ip, QThread &outputThread)
-{
-    InterThreadConnection *itc = new InterThreadConnection(&outputThread);
-    const OutputPortInterface *p0 = dynamic_cast<const OutputPortInterface *>(op.data());
-    const InputPortInterface *p1 = dynamic_cast<const InputPortInterface *>(ip.data());
-    QObject::connect(p0, SIGNAL(transmitSample(const QSharedPointer<const nexxT::DataSample>&)),
-                     itc, SLOT(receiveSample(const QSharedPointer<const nexxT::DataSample>&)));
-    QObject::connect(itc, SIGNAL(transmitInterThread(const QSharedPointer<const nexxT::DataSample> &, QSemaphore *)),
-                     p1, SLOT(receiveAsync(const QSharedPointer<const nexxT::DataSample> &, QSemaphore *)));
-    return itc;
+                     p2pc, SLOT(receiveSample(const QSharedPointer<const nexxT::DataSample>&)),
+                     Qt::DirectConnection);
+    return p2pc;
 }

--- a/nexxT/src/OutputPortInterface.hpp
+++ b/nexxT/src/OutputPortInterface.hpp
@@ -16,7 +16,7 @@
 #include <QtCore/QObject>
 #include <QtCore/QSemaphore>
 #include "NexxTLinkage.hpp"
-#include "DataSamples.hpp"
+#include "SharedPointerTypes.hpp"
 #include "Ports.hpp"
 
 namespace nexxT
@@ -65,17 +65,11 @@ namespace nexxT
         /*!
             Called by the nexxT framework, not intended to be used directly.
         */
-        static void setupDirectConnection(const SharedPortPtr &, const SharedPortPtr &);
-        /*!
-            Called by the nexxT framework, not intended to be used directly.
-        */
-        static QObject *setupInterThreadConnection(const SharedPortPtr &, const SharedPortPtr &, QThread &);
+        static QObject *setupPortToPortConnection(const SharedExecutorPtr &executorFrom,
+                                                  const SharedExecutorPtr &executorTo,
+                                                  const SharedPortPtr &portFrom,
+                                                  const SharedPortPtr &portTo);
     };
-
-    /*!
-        A typedef for an OutputPortInterface instance handled by a shared pointer.
-    */
-    typedef QSharedPointer<OutputPortInterface> SharedOutputPortPtr;
 
 };
 

--- a/nexxT/src/Ports.hpp
+++ b/nexxT/src/Ports.hpp
@@ -16,19 +16,13 @@
 #include <QtCore/QObject>
 #include <QtCore/QSemaphore>
 #include "NexxTLinkage.hpp"
-#include "DataSamples.hpp"
+#include "SharedPointerTypes.hpp"
 
 namespace nexxT
 {
     class BaseFilterEnvironment;
     struct PortD;
-    struct InterThreadConnectionD;
-    class Port;
-
-    /*!
-        A typedef for a Port instance handled by a shared pointer.
-    */
-    typedef QSharedPointer<Port> SharedPortPtr;
+    struct PortToPortConnectionD;
 
     /*!
         This class is the C++ variant of \verbatim embed:rst:inline :py:class:`nexxT.interface.Ports.Port`
@@ -88,23 +82,18 @@ namespace nexxT
         static SharedPortPtr make_shared(Port *port);
     };
 
-    /*!
-        A typedef for a list of ports.
-    */
-    typedef QList<QSharedPointer<Port> > PortList;
-
  //! @cond Doxygen_Suppress
-   class DLLEXPORT InterThreadConnection : public QObject
+   class DLLEXPORT PortToPortConnection : public QObject
     {
         Q_OBJECT
         
-        InterThreadConnectionD *const d;
+        PortToPortConnectionD *const d;
     public:
-        InterThreadConnection(QThread *qthread_from);
-        virtual ~InterThreadConnection();
-
-    signals:
-        void transmitInterThread(const QSharedPointer<const nexxT::DataSample> &sample, QSemaphore *semaphore);
+        PortToPortConnection(const SharedExecutorPtr &executorFrom,
+                              const SharedExecutorPtr &executorTo,
+                              const SharedOutputPortPtr &portFrom,
+                              const SharedInputPortPtr &portTo);
+        virtual ~PortToPortConnection();
 
     public slots:
         void receiveSample(const QSharedPointer<const nexxT::DataSample> &sample);

--- a/nexxT/src/SConscript.py
+++ b/nexxT/src/SConscript.py
@@ -56,6 +56,7 @@ apilib = env.SharedLibrary("nexxT", env.RegisterSources(Split("""
     Services.cpp
     PropertyCollection.cpp
     NexxTPlugins.cpp
+    Executor.cpp
 """)), CPPDEFINES=["NEXXT_LIBRARY_COMPILATION"])
 env.RegisterTargets(apilib)
 
@@ -64,7 +65,7 @@ targets = []
 targets += [spath.Dir("cnexxT").File("cnexxt_module_wrapper.cpp")]
 targets += [spath.Dir("cnexxT").File("nexxt_datasample_wrapper.cpp")]
 targets += [spath.Dir("cnexxT").File("nexxt_port_wrapper.cpp")]
-targets += [spath.Dir("cnexxT").File("nexxt_interthreadconnection_wrapper.cpp")]
+targets += [spath.Dir("cnexxT").File("nexxt_porttoportconnection_wrapper.cpp")]
 targets += [spath.Dir("cnexxT").File("nexxt_outputportinterface_wrapper.cpp")]
 targets += [spath.Dir("cnexxT").File("nexxt_inputportinterface_wrapper.cpp")]
 targets += [spath.Dir("cnexxT").File("nexxt_services_wrapper.cpp")]
@@ -76,10 +77,15 @@ targets += [spath.Dir("cnexxT").File("nexxt_propertyhandler_wrapper.cpp")]
 targets += [spath.Dir("cnexxT").File("nexxt_basefilterenvironment_wrapper.cpp")]
 targets += [spath.Dir("cnexxT").File("nexxt_plugininterface_wrapper.cpp")]
 targets += [spath.Dir("cnexxT").File("nexxt_logging_wrapper.cpp")]
+targets += [spath.Dir("cnexxT").File("nexxt_executor_wrapper.cpp")]
 targets += [spath.Dir("cnexxT").File("qsharedpointer_datasample_wrapper.cpp")]
 targets += [spath.Dir("cnexxT").File("qsharedpointer_filter_wrapper.cpp")]
 targets += [spath.Dir("cnexxT").File("qsharedpointer_port_wrapper.cpp")]
 targets += [spath.Dir("cnexxT").File("qsharedpointer_qobject_wrapper.cpp")]
+targets += [spath.Dir("cnexxT").File("qsharedpointer_executor_wrapper.cpp")]
+targets += [spath.Dir("cnexxT").File("qsharedpointer_inputportinterface_wrapper.cpp")]
+targets += [spath.Dir("cnexxT").File("qsharedpointer_outputportinterface_wrapper.cpp")]
+
 
 env = env.Clone()
 env.Append(LIBS=["nexxT"])

--- a/nexxT/src/Services.cpp
+++ b/nexxT/src/Services.cpp
@@ -7,6 +7,7 @@
 
 #include "Services.hpp"
 #include "Logger.hpp"
+#include <QtCore/QObject>
 #include <QtCore/QMutex>
 #include <QtCore/QMap>
 
@@ -70,9 +71,12 @@ void Services::_removeService(const QString &name)
     if( (d->map.find(name) == d->map.end() ) )
     {
         NEXXT_LOG_WARN(QString("Service %1 doesn't exist. Not removing.").arg(name));
+    } else
+    {
+        NEXXT_LOG_INFO(QString("removing service %1").arg(name));
+        QMetaObject::invokeMethod(d->map[name].data(), "detach", Qt::DirectConnection);
+        d->map.remove(name);
     }
-    NEXXT_LOG_INFO(QString("removing service %1").arg(name));
-    d->map.remove(name);
 }
 
 void Services::_removeAll()

--- a/nexxT/src/SharedPointerTypes.hpp
+++ b/nexxT/src/SharedPointerTypes.hpp
@@ -1,0 +1,44 @@
+#ifndef NEXXT_SHARED_POINTER_TYPES_HPP
+#define NEXXT_SHARED_POINTER_TYPES_HPP
+
+#include <QtCore/QSharedPointer>
+
+namespace nexxT
+{
+    class Port;
+    class InputPortInterface;
+    class OutputPortInterface;
+    class Executor;
+    class DataSample;
+
+    /*!
+        A typedef for a Datasample handled by a shared pointer.
+    */
+    typedef QSharedPointer<const DataSample> SharedDataSamplePtr;
+
+    /*!
+        A typedef for a Port instance handled by a shared pointer.
+    */
+    typedef QSharedPointer<Port> SharedPortPtr;
+
+    /*!
+        A typedef for a Port instance handled by a shared pointer.
+    */
+    typedef QSharedPointer<InputPortInterface> SharedInputPortPtr;
+
+    /*!
+        A typedef for a Port instance handled by a shared pointer.
+    */
+    typedef QSharedPointer<OutputPortInterface> SharedOutputPortPtr;
+
+    /*!
+        A typedef for a Port instance handled by a shared pointer.
+    */
+    typedef QSharedPointer<Executor> SharedExecutorPtr;
+    /*!
+        A typedef for a list of ports.
+    */
+    typedef QList<QSharedPointer<Port> > PortList;
+}
+
+#endif

--- a/nexxT/src/cnexxT.h
+++ b/nexxT/src/cnexxT.h
@@ -17,3 +17,4 @@
 #include "PropertyCollection.hpp"
 #include "NexxTPlugins.hpp"
 #include "Logger.hpp"
+#include "Executor.hpp"

--- a/nexxT/src/cnexxT.xml
+++ b/nexxT/src/cnexxT.xml
@@ -33,7 +33,7 @@
             </modify-function>            
         </object-type>
         
-        <object-type name="InterThreadConnection" allow-thread="true">
+        <object-type name="PortToPortConnection" allow-thread="true">
         </object-type>
         
         <object-type name="Services">
@@ -58,6 +58,11 @@
         </object-type>
         
         <object-type name="InputPortInterface" allow-thread="true">
+            <modify-function signature="receiveAsync(const QSharedPointer&lt;const nexxT::DataSample&gt; &amp;, QSemaphore *)">
+                <modify-argument index="2">
+                    <define-ownership owner="c++"/>
+                </modify-argument>
+            </modify-function>
         </object-type>
         
         <object-type name="OutputPortInterface" allow-thread="true">
@@ -128,6 +133,19 @@
         </object-type>
 
         <object-type name="Logging" />
+
+        <object-type name="Executor">
+            <modify-function signature="make_shared(nexxT::Executor*)">
+                <modify-argument index="1">
+                    <define-ownership owner="c++"/>
+                </modify-argument>
+            </modify-function>
+            <modify-function signature="registerPendingRcvAsync(const QSharedPointer&lt;nexxT::InputPortInterface&gt; &amp;, const QSharedPointer&lt;const nexxT::DataSample&gt; &amp;, QSemaphore *)">
+                <modify-argument index="3">
+                    <define-ownership owner="c++"/>
+                </modify-argument>
+            </modify-function>
+        </object-type>
 
     </namespace-type>
 </typesystem>

--- a/nexxT/tests/core/test_deadlock.json
+++ b/nexxT/tests/core/test_deadlock.json
@@ -1,0 +1,119 @@
+{
+  "_guiState": {
+    "PlaybackControl_showAllFiles": 0
+  },
+  "composite_filters": [],
+  "applications": [
+    {
+      "name": "deadlock",
+      "_guiState": {
+        "filters__PySimpleView": {
+          "MainWindow_MDI_view_geom": "AdnQywABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAH4AAAAAAAAAQgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAABCAAAAAAAAAAA=",
+          "MainWindow_MDI_view_visible": 1
+        }
+      },
+      "nodes": [
+        {
+          "name": "PySimpleSource",
+          "library": "entry_point://tests.nexxT.PySimpleSource",
+          "factoryFunction": "PySimpleSource",
+          "dynamicInputPorts": [],
+          "staticInputPorts": [],
+          "dynamicOutputPorts": [],
+          "staticOutputPorts": [
+            "outPort"
+          ],
+          "thread": "source",
+          "properties": {
+            "frequency": 2.0,
+            "log_tr": true
+          }
+        },
+        {
+          "name": "filt_gui",
+          "library": "entry_point://tests.nexxT.PySimpleStaticFilter",
+          "factoryFunction": "PySimpleStaticFilter",
+          "dynamicInputPorts": [],
+          "staticInputPorts": [
+            "inPort"
+          ],
+          "dynamicOutputPorts": [],
+          "staticOutputPorts": [
+            "outPort"
+          ],
+          "thread": "main",
+          "properties": {
+            "an_enum_property": "e1",
+            "an_int_property": 4223,
+            "log_prefix": "filt_gui:",
+            "log_rcv": true,
+            "sleep_time": 0.0
+          }
+        },
+        {
+          "name": "filt_compute_fast",
+          "library": "entry_point://tests.nexxT.PySimpleStaticFilter",
+          "factoryFunction": "PySimpleStaticFilter",
+          "dynamicInputPorts": [],
+          "staticInputPorts": [
+            "inPort"
+          ],
+          "dynamicOutputPorts": [],
+          "staticOutputPorts": [
+            "outPort"
+          ],
+          "thread": "compute",
+          "properties": {
+            "an_enum_property": "e1",
+            "an_int_property": 4223,
+            "log_prefix": "filt_compute_fast:",
+            "log_rcv": true,
+            "sleep_time": 0.0
+          }
+        },
+        {
+          "name": "filt_compute_slow",
+          "library": "entry_point://tests.nexxT.PySimpleStaticFilter",
+          "factoryFunction": "PySimpleStaticFilter",
+          "dynamicInputPorts": [],
+          "staticInputPorts": [
+            "inPort"
+          ],
+          "dynamicOutputPorts": [],
+          "staticOutputPorts": [
+            "outPort"
+          ],
+          "thread": "compute",
+          "properties": {
+            "an_enum_property": "e1",
+            "an_int_property": 4223,
+            "log_prefix": "filt_compute_slow:",
+            "log_rcv": true,
+            "sleep_time": 1.0
+          }
+        },
+        {
+          "name": "PySimpleView",
+          "library": "entry_point://tests.nexxT.PySimpleView",
+          "factoryFunction": "PySimpleView",
+          "dynamicInputPorts": [],
+          "staticInputPorts": [
+            "in"
+          ],
+          "dynamicOutputPorts": [],
+          "staticOutputPorts": [],
+          "thread": "main",
+          "properties": {
+            "caption": "view"
+          }
+        }
+      ],
+      "connections": [
+        "PySimpleSource.outPort -> filt_gui.inPort",
+        "filt_gui.outPort -> filt_compute_slow.inPort",
+        "filt_compute_slow.outPort -> filt_compute_fast.inPort",
+        "filt_compute_fast.outPort -> PySimpleView.in"
+      ]
+    }
+  ]
+}

--- a/nexxT/tests/integration/test_gui.py
+++ b/nexxT/tests/integration/test_gui.py
@@ -1255,6 +1255,7 @@ class ExecutionOrderTest(GuiTestBase):
                 M = re.match(r'layer1_f1:throughput: (\d+.\d+) samples/second', msg)
                 if M is not None:
                     throughput = float(M.group(1))
+            self.record_property("throughput_smp_per_sec", throughput)
             assert throughput > 1000
         finally:
             if not self.keep_open:
@@ -1262,11 +1263,12 @@ class ExecutionOrderTest(GuiTestBase):
                     QTimer.singleShot(self.delay, self.clickDiscardChanges)
                 mw.close()
 
-    def test(self):
+    def test(self, record_property):
         """
         test property editing in config editor
         :return:
         """
+        self.record_property = record_property
         QTimer.singleShot(self.delay, self._stage0)
         startNexT(str(Path(__file__).parent.parent / "core" / "test_tree_order.json"), None, [], [], True)
         QTimer.singleShot(self.delay, self._stage1)
@@ -1277,6 +1279,6 @@ class ExecutionOrderTest(GuiTestBase):
 
 @pytest.mark.gui
 @pytest.mark.parametrize("delay", [300])
-def test_executionOrder(qtbot, xvfb, keep_open, delay, tmpdir):
+def test_executionOrder(qtbot, xvfb, keep_open, delay, tmpdir, record_property):
     test = ExecutionOrderTest(qtbot, xvfb, keep_open, delay, tmpdir)
-    test.test()
+    test.test(record_property)

--- a/workspace/pytest_nexxT.sh
+++ b/workspace/pytest_nexxT.sh
@@ -5,7 +5,7 @@ else
   PYTEST="$1"
 fi
 
-ADD_FLAGS="-v"
+ADD_FLAGS=""
 
 # release variant
                       "$PYTEST" -m     "gui" $ADD_FLAGS              --cov=nexxT.core --cov=nexxT.interface --cov=nexxT.services --cov=nexxT.filters --cov-report html --forked ../nexxT/tests


### PR DESCRIPTION
This PR addresses the deadlock issue described here https://github.com/ifm/nexxT/issues/25. Note the following side effects of this fix:

- The computational graph processing order is changed from depth first search to breadth first search
- Connections between filters running in the same thread are not processed immediately during the outputPort.transmit(...) function anymore. Instead, the transmitted samples are enqueued and processed later on.
- The InterThreadConnection class has been replaced by a PortToPortConnection class. This class handles both, intra- and inter-thread connections. The PortToPortConnection instances live in the threads of the output ports.
- A new class Executor is introduced, each thread has exactly one instance of this class. This class dispatches the enqueued transmit calls
   - PortToPortConnections pass onPortDataChanged events directly to the executor's queue, if the connection is intra-thread
   - In case of inter-thread connections, the connection's semaphore is tried to be acquired. If this succeeds, the onPortDataChanged event is enqueued in the input port's executor instance. Otherwise - to prevent the deadlocks - the output port's executor is allowed to process events (but the QT event loop will not be processed). 
