### PR TITLE
implement blocking/nonblocking connections

### DIFF
--- a/nexxT/core/ActiveApplication.py
+++ b/nexxT/core/ActiveApplication.py
@@ -161,11 +161,13 @@ class ActiveApplication(QObject):
                 for idx in range(len(proxy[compName, fromPort])):
                     if proxy[compName, fromPort][idx] is None:
                         continue
-                    proxyNode, proxyPort = proxy[compName, fromPort][idx]
+                    proxyNode, proxyPort, w = proxy[compName, fromPort][idx]
                     # if fromNode is itself a composite node, resolve it
                     if (proxyNode, proxyPort) in proxy:
                         changed = True
                         proxy[compName, fromPort][idx] = None
+                        for _, _, widths in proxy[proxyNode, proxyPort]:
+                            widths.extend(w)
                         proxy[compName, fromPort].extend(proxy[proxyNode, proxyPort])
         # remove None's
         for compName, fromPort in proxy:
@@ -189,13 +191,15 @@ class ActiveApplication(QObject):
             for fromPort in subgraph.allOutputPorts(cin_node):
                 proxyInputPorts[compName, fromPort] = []
                 for _, _, toNode, toPort in subgraph.allConnectionsFromOutputPort(cin_node, fromPort):
-                    proxyInputPorts[compName, fromPort].append((compName + "/" + toNode, toPort))
+                    width = subgraph.getConnectionProperties(cin_node, fromPort, toNode, toPort)["width"]
+                    proxyInputPorts[compName, fromPort].append((compName + "/" + toNode, toPort, [width]))
                 proxyOutputPorts[compName + "/" + cin_node, fromPort] = []
             cout_node = "CompositeOutput"
             for toPort in subgraph.allInputPorts(cout_node):
                 proxyOutputPorts[compName, toPort] = []
                 for fromNode, fromPort, _, _ in subgraph.allConnectionsToInputPort(cout_node, toPort):
-                    proxyOutputPorts[compName, toPort].append((compName + "/" + fromNode, fromPort))
+                    width = subgraph.getConnectionProperties(fromNode, fromPort, cout_node, toPort)["width"]
+                    proxyOutputPorts[compName, toPort].append((compName + "/" + fromNode, fromPort, [width]))
                 proxyInputPorts[compName + "/" + cout_node, toPort] = []
 
         return self._compress(proxyInputPorts), self._compress(proxyOutputPorts)
@@ -211,22 +215,24 @@ class ActiveApplication(QObject):
 
         for namePrefix, graph in allGraphs:
             for fromNode, fromPort, toNode, toPort in graph.allConnections():
+                width = graph.getConnectionProperties(fromNode, fromPort, toNode, toPort)["width"]
                 fromName = namePrefix + "/" + fromNode
                 toName = namePrefix + "/" + toNode
 
                 if (fromName, fromPort) in proxyOutputPorts:
                     src = proxyOutputPorts[fromName, fromPort]
                 else:
-                    src = [(fromName, fromPort)]
+                    src = [(fromName, fromPort, [width])]
 
                 if (toName, toPort) in proxyInputPorts:
                     dest = proxyInputPorts[toName, toPort]
                 else:
-                    dest = [(toName, toPort)]
+                    dest = [(toName, toPort, [width])]
 
                 for s in src:
                     for d in dest:
-                        res.append(s + d)
+                        widths = set(s[2] + d[2] + [width])
+                        res.append((s[:2] + d[:2], 0 if 0 in widths else max(widths)))
         return res
 
     def _setupConnections(self):
@@ -239,7 +245,7 @@ class ActiveApplication(QObject):
         graph = {}
         if self._graphConnected:
             return
-        for fromNode, fromPort, toNode, toPort in self._allConnections():
+        for (fromNode, fromPort, toNode, toPort), width in self._allConnections():
             fromThread = self._filters2threads[fromNode]
             toThread = self._filters2threads[toNode]
             t0 = self._threads[fromThread]
@@ -249,13 +255,14 @@ class ActiveApplication(QObject):
             if toThread == fromThread:
                 OutputPortInterface.setupDirectConnection(p0, p1)
             else:
-                itc = OutputPortInterface.setupInterThreadConnection(p0, p1, self._threads[fromThread].qthread())
+                itc = OutputPortInterface.setupInterThreadConnection(p0, p1, self._threads[fromThread].qthread(), width)
                 self._interThreadConns.append(itc)
                 if not fromThread in graph:
                     graph[fromThread] = set()
                 if not toThread in graph:
                     graph[toThread] = set()
-                graph[fromThread].add(toThread)
+                if width > 0:
+                    graph[fromThread].add(toThread)
 
         def _checkCycle(thread, cycleInfo):
             if thread in cycleInfo:

--- a/nexxT/core/BaseGraph.py
+++ b/nexxT/core/BaseGraph.py
@@ -168,7 +168,7 @@ class BaseGraph(QObject):
         :param portNameFrom: the source port
         :param nodeNameTo: the target node
         :param portNameTo: the target port
-        :return: NoWne
+        :return: None
         """
         assertMainThread()
         if (nodeNameFrom, portNameFrom, nodeNameTo, portNameTo) not in self._connections:

--- a/nexxT/core/BaseGraph.py
+++ b/nexxT/core/BaseGraph.py
@@ -9,16 +9,20 @@ This module defines the class BaseGraph
 """
 
 from collections import OrderedDict
+import logging
 from nexxT.Qt.QtCore import QObject, Signal, Slot
 from nexxT.core.Utils import assertMainThread
 from nexxT.core.Exceptions import (NodeExistsError, NodeNotFoundError, PortExistsError, PortNotFoundError,
                                    ConnectionExistsError, ConnectionNotFound, NodeProtectedError)
 
+logger = logging.getLogger(__name__)
+
 class BaseGraph(QObject):
     """
     This class defines a graph where the nodes can have input and output ports and
-    these ports can be connected together. All operations are performed with QT
-    signals and slots.
+    these ports can be connected together. Connections have a property dictionary.
+
+    All operations are performed with QT signals and slots.
     """
     nodeAdded = Signal(str)
     nodeRenamed = Signal(str, str)
@@ -33,12 +37,14 @@ class BaseGraph(QObject):
     connectionDeleted = Signal(str, str, str, str)
     dirtyChanged = Signal()
 
-    def __init__(self):
+    def __init__(self, defaultConnProp=None):
         assertMainThread()
         super().__init__()
         self._protected = set()
         self._nodes = OrderedDict()
         self._connections = []
+        self._connectionProps = {}
+        self._defaultConnProp = {} if defaultConnProp is None else defaultConnProp.copy()
 
     def uniqueNodeName(self, nodeName):
         """
@@ -148,8 +154,10 @@ class BaseGraph(QObject):
             raise PortNotFoundError(nodeNameTo, portNameTo, "Input")
         if (nodeNameFrom, portNameFrom, nodeNameTo, portNameTo) in self._connections:
             raise ConnectionExistsError(nodeNameFrom, portNameFrom, nodeNameTo, portNameTo)
-        self._connections.append((nodeNameFrom, portNameFrom, nodeNameTo, portNameTo))
-        self.connectionAdded.emit(nodeNameFrom, portNameFrom, nodeNameTo, portNameTo)
+        conn = (nodeNameFrom, portNameFrom, nodeNameTo, portNameTo)
+        self._connections.append(conn)
+        self._connectionProps[conn] = self._defaultConnProp.copy()
+        self.connectionAdded.emit(*conn)
         self.dirtyChanged.emit()
 
     @Slot(str, str, str, str)
@@ -165,8 +173,10 @@ class BaseGraph(QObject):
         assertMainThread()
         if (nodeNameFrom, portNameFrom, nodeNameTo, portNameTo) not in self._connections:
             raise ConnectionNotFound(nodeNameFrom, portNameFrom, nodeNameTo, portNameTo)
-        self._connections.remove((nodeNameFrom, portNameFrom, nodeNameTo, portNameTo))
-        self.connectionDeleted.emit(nodeNameFrom, portNameFrom, nodeNameTo, portNameTo)
+        conn = (nodeNameFrom, portNameFrom, nodeNameTo, portNameTo)
+        self._connections.remove(conn)
+        del self._connectionProps[conn]
+        self.connectionDeleted.emit(*conn)
         self.dirtyChanged.emit()
 
     @Slot(str, str)
@@ -228,10 +238,15 @@ class BaseGraph(QObject):
             raise PortExistsError(node, newPortName)
         idx = self._nodes[node]["inports"].index(oldPortName)
         self._nodes[node]["inports"][idx] = newPortName
-        for i, (fromNode, fromPort, toNode, toPort) in enumerate(self._connections):
+        for i, oldConn in enumerate(self._connections):
+            (fromNode, fromPort, toNode, toPort) = oldConn
             if (toNode == node and toPort == oldPortName):
                 toPort = newPortName
-            self._connections[i] = (fromNode, fromPort, toNode, toPort)
+            newConn = (fromNode, fromPort, toNode, toPort)
+            self._connections[i] = newConn
+            p = self._connectionProps[oldConn]
+            del self._connectionProps[oldConn]
+            self._connectionProps[newConn] = p
         self.inPortRenamed.emit(node, oldPortName, newPortName)
 
     @Slot(str, str)
@@ -293,10 +308,15 @@ class BaseGraph(QObject):
             raise PortExistsError(node, newPortName)
         idx = self._nodes[node]["outports"].index(oldPortName)
         self._nodes[node]["outports"][idx] = newPortName
-        for i, (fromNode, fromPort, toNode, toPort) in enumerate(self._connections):
+        for i, oldConn in enumerate(self._connections):
+            (fromNode, fromPort, toNode, toPort) = oldConn
             if (fromNode == node and fromPort == oldPortName):
                 fromPort = newPortName
-            self._connections[i] = (fromNode, fromPort, toNode, toPort)
+            newConn = (fromNode, fromPort, toNode, toPort)
+            self._connections[i] = newConn
+            p = self._connectionProps[oldConn]
+            del self._connectionProps[oldConn]
+            self._connectionProps[newConn] = p
         self.outPortRenamed.emit(node, oldPortName, newPortName)
 
     def allNodes(self):
@@ -327,11 +347,43 @@ class BaseGraph(QObject):
     def allConnectionsFromOutputPort(self, fromNode, fromPort):
         """
         Return all connections from the specified port.
+
         :param fromNode: name of node
         :param fromPort: name of port
         :return: a list of 4 tuples of strings (nodeFrom, portFrom, nodeTo, portTo)
         """
         return [(a, b, c, d) for a, b, c, d, in self._connections if (a == fromNode and b == fromPort)]
+
+    def getConnectionProperties(self, nodeFrom, portFrom, nodeTo, portTo):
+        """
+        Return the connection properties of the specified connection
+
+        :param nodeFrom: name of the output node
+        :param portFrom: name of the output port
+        :param nodeTo: name of the input node
+        :param portTo: name of the input port
+        :return: a copy of the property dict (use setConnectionProperties to modify this)
+        """
+        if (nodeFrom, portFrom, nodeTo, portTo) not in self._connectionProps:
+            logger.info("connprops.keys()=%s", self._connectionProps.keys())
+            raise ConnectionNotFound(nodeFrom, portFrom, nodeTo, portTo)
+        return self._connectionProps[nodeFrom, portFrom, nodeTo, portTo].copy()
+
+    def setConnectionProperties(self, nodeFrom, portFrom, nodeTo, portTo, properties):
+        """
+        Set the connection properties of the specified connection to the given dict.
+
+        :param nodeFrom: name of the output node
+        :param portFrom: name of the output port
+        :param nodeTo: name of the input node
+        :param portTo: name of the input port
+        :param properties: a dict with the new properties
+        """
+        if (nodeFrom, portFrom, nodeTo, portTo) not in self._connectionProps:
+            raise ConnectionNotFound(nodeFrom, portFrom, nodeTo, portTo)
+        logger.info("set connprop: %s.%s -> %s.%s (%s)", nodeFrom, portFrom, nodeTo, portTo, properties)
+        self._connectionProps[nodeFrom, portFrom, nodeTo, portTo] = properties
+        self.dirtyChanged.emit()
 
     def allInputPorts(self, node):
         """

--- a/nexxT/core/ConfigFileSchema.json
+++ b/nexxT/core/ConfigFileSchema.json
@@ -16,7 +16,7 @@
     "connection": {
       "description": "Used for specifying a connection.",
       "type": "string",
-      "pattern": "^[A-Za-z_][A-Za-z0-9_-]*[.][A-Za-z_][A-Za-z0-9_-]*\\s*[-][>]\\s*[A-Za-z_][A-Za-z0-9_-]*[.][A-Za-z_][A-Za-z0-9_-]*$"
+      "pattern": "^[A-Za-z_][A-Za-z0-9_-]*[.][A-Za-z_][A-Za-z0-9_-]*\\s*[-]\\d*[>]\\s*[A-Za-z_][A-Za-z0-9_-]*[.][A-Za-z_][A-Za-z0-9_-]*$"
     },
     "propertySection": {
       "type": "object",

--- a/nexxT/core/Graph.py
+++ b/nexxT/core/Graph.py
@@ -32,7 +32,7 @@ class FilterGraph(BaseGraph):
     dynOutputPortDeleted = Signal(str, str)
 
     def __init__(self, subConfig):
-        super().__init__()
+        super().__init__(defaultConnProp=dict(width=1))
         assertMainThread()
         self._parent = subConfig
         self._filters = {}

--- a/nexxT/core/PortImpl.py
+++ b/nexxT/core/PortImpl.py
@@ -24,10 +24,10 @@ class InterThreadConnection(QObject):
     """
     transmitInterThread = Signal(object, QSemaphore)
 
-    def __init__(self, qthreadFrom):
+    def __init__(self, qthreadFrom, width):
         super().__init__()
         self.moveToThread(qthreadFrom)
-        self.semaphore = QSemaphore(1)
+        self.semaphore = QSemaphore(width) if width > 0 else None
         self._stopped = True
 
     def receiveSample(self, dataSample):
@@ -45,7 +45,7 @@ class InterThreadConnection(QObject):
             if self._stopped:
                 logger.info("The inter-thread connection is set to stopped mode; data sample discarded.")
                 break
-            if self.semaphore.tryAcquire(1, 500):
+            if self.semaphore is None or self.semaphore.tryAcquire(1, 500):
                 self.transmitInterThread.emit(dataSample, self.semaphore)
                 break
 
@@ -101,18 +101,19 @@ class OutputPortImpl(OutputPortInterface):
         outputPort.transmitSample.connect(inputPort.receiveSync, Qt.DirectConnection)
 
     @staticmethod
-    def setupInterThreadConnection(outputPort, inputPort, outputPortThread):
+    def setupInterThreadConnection(outputPort, inputPort, outputPortThread, width):
         """
         Setup an inter thread connection between outputPort and inputPort
 
         :param outputPort: the output port instance to be connected
         :param inputPort: the input port instance to be connected
         :param outputPortThread: the QThread instance of the outputPort instance
+        :param width: the width of the connection in DataSamples (0: infinite)
         :return: an InterThreadConnection instance which manages the connection (has
                  to survive until connections is deleted)
         """
         logger.info("setup inter thread connection between %s -> %s", outputPort.name(), inputPort.name())
-        itc = InterThreadConnection(outputPortThread)
+        itc = InterThreadConnection(outputPortThread, width)
         outputPort.transmitSample.connect(itc.receiveSample, Qt.DirectConnection)
         itc.transmitInterThread.connect(inputPort.receiveAsync, Qt.QueuedConnection)
         return itc
@@ -206,10 +207,11 @@ class InputPortImpl(InputPortInterface):
         if not QThread.currentThread() is self.thread():
             raise NexTInternalError("InputPort.receiveAsync has been called from an unexpected thread.")
         self._addToQueue(dataSample)
-        if not self._interthreadDynamicQueue:
+        if not self._interthreadDynamicQueue or semaphore is None:
             # usual behaviour
             self._transmit()
-            semaphore.release(1)
+            if semaphore is not None:
+                semaphore.release(1)
         else:
             if semaphore not in self._semaphoreN:
                 self._semaphoreN[semaphore] = 1

--- a/nexxT/services/gui/GraphEditorView.py
+++ b/nexxT/services/gui/GraphEditorView.py
@@ -77,7 +77,7 @@ class GraphEditorView(QGraphicsView):
             saved["nodes"] = saved["nodes"][:i] + saved["nodes"][i+1:]
         cToDel = set()
         for c in saved["connections"]:
-            node1, _, node2, _ = SubConfiguration.connectionStringToTuple(c)
+            node1, _, node2, _, _ = SubConfiguration.connectionStringToTuple(c)
             if node1 in deletedNodes or node2 in deletedNodes:
                 cToDel.add(c)
         for c in cToDel:
@@ -107,10 +107,10 @@ class GraphEditorView(QGraphicsView):
                 n["name"] = nameTransformations[n["name"]]
             newConn = []
             for c in cfg["connections"]:
-                node1, port1, node2, port2 = SubConfiguration.connectionStringToTuple(c)
+                node1, port1, node2, port2, props = SubConfiguration.connectionStringToTuple(c)
                 node1 = nameTransformations[node1]
                 node2 = nameTransformations[node2]
-                newConn.append(SubConfiguration.tupleToConnectionString((node1, port1, node2, port2)))
+                newConn.append(SubConfiguration.tupleToConnectionString((node1, port1, node2, port2, props)))
             cfg["connections"] = newConn
             def compositeLookup(name):
                 return self.scene().graph.getSubConfig().getConfiguration().compositeFilterByName(name)

--- a/nexxT/src/InputPortInterface.cpp
+++ b/nexxT/src/InputPortInterface.cpp
@@ -219,10 +219,13 @@ void InputPortInterface::receiveAsync(const QSharedPointer<const DataSample> &sa
             stackDepth--;
         }
         addToQueue(sample);
-        if(!d->interthreadDynamicQueue)
+        if( (!d->interthreadDynamicQueue) || (!semaphore) )
         {
             transmit();
-            semaphore->release(1);
+            if(semaphore)
+            {
+                semaphore->release(1);
+            }
         } else
         {
             if( d->semaphoreN.find(semaphore) == d->semaphoreN.end() )

--- a/nexxT/src/OutputPortInterface.cpp
+++ b/nexxT/src/OutputPortInterface.cpp
@@ -47,9 +47,9 @@ void OutputPortInterface::setupDirectConnection(const SharedPortPtr &op, const S
                      p1, SLOT(receiveSync(const QSharedPointer<const nexxT::DataSample> &)));
 }
 
-QObject *OutputPortInterface::setupInterThreadConnection(const SharedPortPtr &op, const SharedPortPtr &ip, QThread &outputThread)
+QObject *OutputPortInterface::setupInterThreadConnection(const SharedPortPtr &op, const SharedPortPtr &ip, QThread &outputThread, int width)
 {
-    InterThreadConnection *itc = new InterThreadConnection(&outputThread);
+    InterThreadConnection *itc = new InterThreadConnection(&outputThread, width);
     const OutputPortInterface *p0 = dynamic_cast<const OutputPortInterface *>(op.data());
     const InputPortInterface *p1 = dynamic_cast<const InputPortInterface *>(ip.data());
     QObject::connect(p0, SIGNAL(transmitSample(const QSharedPointer<const nexxT::DataSample>&)),

--- a/nexxT/src/OutputPortInterface.hpp
+++ b/nexxT/src/OutputPortInterface.hpp
@@ -69,7 +69,7 @@ namespace nexxT
         /*!
             Called by the nexxT framework, not intended to be used directly.
         */
-        static QObject *setupInterThreadConnection(const SharedPortPtr &, const SharedPortPtr &, QThread &);
+        static QObject *setupInterThreadConnection(const SharedPortPtr &, const SharedPortPtr &, QThread &, int width);
     };
 
 };

--- a/nexxT/src/Ports.hpp
+++ b/nexxT/src/Ports.hpp
@@ -89,7 +89,7 @@ namespace nexxT
 
         InterThreadConnectionD *const d;
     public:
-        InterThreadConnection(QThread *qthread_from);
+        InterThreadConnection(QThread *qthread_from, int width);
         virtual ~InterThreadConnection();
 
     signals:

--- a/workspace/requirements.txt
+++ b/workspace/requirements.txt
@@ -2,11 +2,11 @@ PySide6==6.4.0
 scons==4.3.0
 shiboken6==6.4.0
 shiboken6-generator==6.4.0
-pytest==6.1.2
-pytest-cov==2.10.1
+pytest==7.1.3
+pytest-cov==4.0.0
 pylint==2.15.4
-pytest-qt==4.0.2
+pytest-qt==4.1.0
 pytest-xvfb==2.0.0
-pytest-xdist==2.1.0
-pytest-timeout==2.0.1
+pytest-xdist==2.5.0
+pytest-timeout==2.1.0
 -e ..


### PR DESCRIPTION
add a connection attribute "width" for specifying the maximum number of pending samples in inter-thread connections. If this is set to 0, the connection is set to non-blocking (resulting in infinite number of pending samples) and the connection is not taking part in the deadlock cycle check.