### PR TITLE
MainWindow enhancements

### DIFF
--- a/nexxT/services/gui/MainWindow.py
+++ b/nexxT/services/gui/MainWindow.py
@@ -626,7 +626,7 @@ with the <a href='https://github.com/ifm/nexxT/blob/master/NOTICE'>notice</a>.
         act = QAction("<unnamed>", self)
         def ensureVisible():
             # see issue https://github.com/ifm/nexxT/issues/64
-            if window.isFloating():
+            if isinstance(window, QDockWidget) and window.isFloating():
                 window.setFloating(False)
             window.setVisible(True)
             act.setChecked(True)


### PR DESCRIPTION
- add "close all plots", "show all plots", "cascade" and "tile" shortcuts to the window menu
- provide an extra sub-menu for managing the visibility of dock windows
- fix hiding and re-showing undocked dock windows sometimes cause the windows to disappear (https://github.com/ifm/nexxT/issues/64)