### PR TITLE
Improve deadlock behaviour at deinit/exit

### DIFF
--- a/nexxT/core/ActiveApplication.py
+++ b/nexxT/core/ActiveApplication.py
@@ -98,7 +98,7 @@ class ActiveApplication(QObject):
                     threadName = "main"
                 if threadName not in self._threads:
                     # create threads as needed
-                    self._threads[threadName] = NexTThread(threadName)
+                    self._threads[threadName] = NexTThread(threadName, len(self._threads))
                 self._threads[threadName].addMockup(filtername, mockup, props)
                 self._filters2threads[filtername] = threadName
 


### PR DESCRIPTION
- fix Barrier for spurious wakeups (see https://stackoverflow.com/a/79446755/29686371)
- reduce deadlock probability by performing close/deinit/destruct operation in a non-parallel manner
- potentially fix https://github.com/ifm/nexxT/issues/63